### PR TITLE
Example demonstrating that reviewdog overwrites comments from other runs

### DIFF
--- a/.github/workflows/using-original-action.yml
+++ b/.github/workflows/using-original-action.yml
@@ -1,0 +1,22 @@
+name: Using original action
+
+on:
+  pull_request:
+
+jobs:
+  terraform_validate:
+    name: runner / terraform validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        root_module:
+          - development
+          - production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-terraform-validate@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          workdir: ./terraform/${{ matrix.root_module }}
+          reporter: github-pr-review
+          level: warning

--- a/terraform/development/bad.tf
+++ b/terraform/development/bad.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "bad" {
+  ami = "ami-065deacbcaac64cf2"
+  # instance_type = "t2.micro" # required argument; must be reported!
+}

--- a/terraform/development/provider.tf
+++ b/terraform/development/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.73.0"
+    }
+  }
+}

--- a/terraform/production/bad.tf
+++ b/terraform/production/bad.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "bad" {
+  # ami = "ami-065deacbcaac64cf2" # required argument; must be reported!
+  instance_type = "t2.micro"
+}

--- a/terraform/production/provider.tf
+++ b/terraform/production/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.73.0"
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR demonstrates that the current `reviewdog/action-terraform-validate` cannot leave review comments correctly on monorepos containing multiple Terraform root modules.

## Details

This PR adds the following two root module, both of which contain issues to be reported by reviewdog:

- `terraform/development`
- `terraform/production`

The `terraform validate` command should be run on each root module, so I set up two jobs and used `reviewdog/action-terraform-validate` on both modules respectively in `using-original-action.yml`.

However, as you can see, reviewdog only reported an issue from `terraform/development`.

This happened because the review comments reported by one job are overwritten by another job.