### PR TITLE
Example demonstrating that the issue has been resolved

### DIFF
--- a/.github/workflows/using-improved-action.yml
+++ b/.github/workflows/using-improved-action.yml
@@ -1,0 +1,24 @@
+name: Using improved action
+
+on:
+  pull_request:
+
+jobs:
+  terraform_validate:
+    name: runner / terraform validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        root_module:
+          - development
+          - production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          github_token: ${{ secrets.github_token }}
+          workdir: ./terraform/${{ matrix.root_module }}
+          reporter: github-pr-review
+          level: warning
+          # Explicitly specify a unique name for each job to prevent reviewdog from overwriting comments across jobs.
+          name: terraform validate (${{ matrix.root_module }})

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ inputs:
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: 'false'
+  name:
+    description: |
+      Tool name shown in review comment for reviewdog.
+      Also serves as an identifier to indicate which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+    default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''
@@ -48,6 +54,8 @@ inputs:
 ```
 
 ## Usage
+
+### For single root module
 
 ```yaml
 name: reviewdog
@@ -66,4 +74,32 @@ jobs:
           # Change reporter level if you need.
           # GitHub Status Check won't become failure with warning.
           level: warning
+```
+
+### For multiple root modules
+
+```yaml
+name: reviewdog
+on: [pull_request]
+jobs:
+  terraform_validate:
+    name: runner / terraform validate
+    strategy:
+      matrix:
+        root_module:
+          - development
+          - production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-terraform-validate@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-pr-review
+          # Change reporter level if you need.
+          # GitHub Status Check won't become failure with warning.
+          level: warning
+          # Explicitly specify a unique name for each job to prevent reviewdog from overwriting comments across jobs.
+          name: terraform validate ${{ matrix.root_module }}
 ```

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ inputs:
   name:
     description: |
       Tool name shown in review comment for reviewdog.
-      Also serves as an identifier to indicate which comments reviewdog should overwrite.
-      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+      Also acts as an identifier for determining which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to run multiple times.
     default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     default: 'false'
+  name:
+    description: |
+      Tool name shown in review comment for reviewdog.
+      Also serves as an identifier to indicate which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+    default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'
     default: ''

--- a/action.yml
+++ b/action.yml
@@ -31,8 +31,8 @@ inputs:
   name:
     description: |
       Tool name shown in review comment for reviewdog.
-      Also serves as an identifier to indicate which comments reviewdog should overwrite.
-      Useful in monorepos with multiple root modules where terraform validate needs to be run multiple times.
+      Also acts as an identifier for determining which comments reviewdog should overwrite.
+      Useful in monorepos with multiple root modules where terraform validate needs to run multiple times.
     default: 'terraform validate'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ terraform init -backend=false
 terraform validate -json \
   | jq "$jq_script" -c \
   | reviewdog -f="rdjsonl" \
-      -name="terraform validate" \
+      -name="${INPUT_NAME}" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \

--- a/terraform/development/bad.tf
+++ b/terraform/development/bad.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "bad" {
+  ami = "ami-065deacbcaac64cf2"
+  # instance_type = "t2.micro" # required argument; must be reported!
+}

--- a/terraform/development/provider.tf
+++ b/terraform/development/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.73.0"
+    }
+  }
+}

--- a/terraform/production/bad.tf
+++ b/terraform/production/bad.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "bad" {
+  # ami = "ami-065deacbcaac64cf2" # required argument; must be reported!
+  instance_type = "t2.micro"
+}

--- a/terraform/production/provider.tf
+++ b/terraform/production/provider.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.73.0"
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR demonstrates that PR https://github.com/reviewdog/action-terraform-validate/pull/39 resolves the issue addressed in #1.


## Details

The situation is the same as #1.

The difference from #1 is that I am using the `-name` input introduced in https://github.com/reviewdog/action-terraform-validate/pull/39 and specifying a unique name for each job in `using-improved-action.yml`.

As a result, reviewdog can report issues from both `terraform/development` and `terraform/production`.